### PR TITLE
Optimizing the get_current_chat_logger ()

### DIFF
--- a/core/logger.py
+++ b/core/logger.py
@@ -36,21 +36,20 @@ def setup_logger():
 
 
 def get_current_chat_logger(chat_id: int) -> logging.Logger:
-    def remove_all_handlers(logger: logging.Logger):
-        for handler in logger.handlers:
-            logger.removeHandler(handler)
-
     logger = logging.getLogger(f'chat_{chat_id}')
-    remove_all_handlers(logger)
+    logger.propagate = False
 
-    os.makedirs(settings.LOGS_DIR_CHATS, exist_ok=True)
-    filepath = os.path.join(settings.LOGS_DIR_CHATS, f'{chat_id}.log')
+    if logger.hasHandlers():
+        return logger
+    else:
 
-    handler = logging.FileHandler(filename=filepath, encoding='utf-8')
-    handler.setLevel(logging.DEBUG)
-    handler.setFormatter(logging.Formatter(settings.LOGS_FORMAT))
+        os.makedirs(settings.LOGS_DIR_CHATS, exist_ok=True)
+        filepath = os.path.join(settings.LOGS_DIR_CHATS, f'{chat_id}.log')
+        handler = logging.FileHandler(filename=filepath, encoding='utf-8')
+        handler.setLevel(logging.DEBUG)
+        handler.setFormatter(logging.Formatter(settings.LOGS_FORMAT))
 
-    logger.addHandler(handler)
+        logger.addHandler(handler)
     return logger
 
 


### PR DESCRIPTION
**RU**

Переработана функция get_current_chat_logger для устранения двух фундаментальных проблем.

Проблемы:

- Неэффективное использование логгеров: Поскольку logging.getLogger() возвращает синглтон, код выполнял лишние операции по удалению и повторному добавлению одних и тех же хендлеров на каждый вызов функции.

- Риск исчерпания файловых дескрипторов: При удалении хендлера не вызывался критически важный метод .close(), что приводило к утечке ресурсов. В условиях высокой нагрузки это могло привести к аварийному завершению работы приложения.

В любом разе в моем pr, это уже не будет важным, так как решаются оба этих проблем.


**EN**

Rewrote the `get_current_chat_logger` function to address two fundamental issues.

Issues:

- **Inefficient logger usage**: Since `logging.getLogger()` returns a singleton, the code was performing unnecessary operations of removing and re-adding the same handlers on every function call.

- **Risk of file descriptor exhaustion**: When removing a handler, the critical `.close()` method was not being called, leading to resource leaks. Under high load, this could cause the application to crash.

In any case, in my PR, this will no longer be relevant as both of these issues are resolved.